### PR TITLE
Use mongodb to match slugs

### DIFF
--- a/index.js
+++ b/index.js
@@ -156,7 +156,10 @@ module.exports = function(slugFields, options) {
           fields = {};
 
       q._id = {$ne: doc._id};
-      q[options.field] = new RegExp('^' + (slugLimited ? slug.substr(0, slug.length - 2) : slug));
+
+      var trailing_re = "(" + options.separator + "[0-9]+)?$";
+
+      q[options.field] = new RegExp('^' + (slugLimited ? slug.substr(0, slug.length - 2) : slug ) + trailing_re);
       fields[options.field] = 1;
       model.find(q, fields).exec(function(e, docs) {
         if (e) return cb(e);

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "name": "mongoose-url-slugs",
   "description": "Create URL compatiable slugs on mongoose models, ensuring uniqueness.",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "keywords": [
     "mongoose slugs",
     "mongoose url slugs",


### PR DESCRIPTION
While using this module with a large dataset I found a issue where this plugin will fetch records from mongo and then filter them out in code.

Specifically this query https://github.com/talha-asad/mongoose-url-slugs/blob/master/index.js#L159 

This fix will use mongodb to filter these slugs instead.